### PR TITLE
Logout all tokens

### DIFF
--- a/Digipost/APIClient+URLSessionTask.swift
+++ b/Digipost/APIClient+URLSessionTask.swift
@@ -87,7 +87,6 @@ extension APIClient {
         let request = Alamofire.download(urlRequest) { (tempURL, response) -> (NSURL) in
             let baseEncryptionModel : POSBaseEncryptedModel? = {
                 if let attachment = encryptionModel as? POSAttachment {
-                    println(POSModelManager.sharedManager().managedObjectContext)
                     return POSAttachment.existingAttachmentWithUri(downloadURI, inManagedObjectContext: POSModelManager.sharedManager().managedObjectContext!) as POSBaseEncryptedModel?
                 } else {
                     return POSReceipt.existingReceiptWithUri(downloadURI, inManagedObjectContext: POSModelManager.sharedManager().managedObjectContext!) as POSBaseEncryptedModel

--- a/Digipost/APIClient+URLSessionTask.swift
+++ b/Digipost/APIClient+URLSessionTask.swift
@@ -85,13 +85,18 @@ extension APIClient {
         var completedURL : NSURL?
         let downloadURI = encryptionModel.uri
         let request = Alamofire.download(urlRequest) { (tempURL, response) -> (NSURL) in
-            let baseEncryptionModel : POSBaseEncryptedModel = {
+            let baseEncryptionModel : POSBaseEncryptedModel? = {
                 if let attachment = encryptionModel as? POSAttachment {
-                    return POSAttachment.existingAttachmentWithUri(downloadURI, inManagedObjectContext: POSModelManager.sharedManager().managedObjectContext!) as POSBaseEncryptedModel
+                    println(POSModelManager.sharedManager().managedObjectContext)
+                    return POSAttachment.existingAttachmentWithUri(downloadURI, inManagedObjectContext: POSModelManager.sharedManager().managedObjectContext!) as POSBaseEncryptedModel?
                 } else {
                     return POSReceipt.existingReceiptWithUri(downloadURI, inManagedObjectContext: POSModelManager.sharedManager().managedObjectContext!) as POSBaseEncryptedModel
                 }}()
-            let filePath = baseEncryptionModel.decryptedFilePath()
+            // model was deleted while downloading
+            if baseEncryptionModel == nil {
+                return NSURL(string: "")! // Alamofire won't allow returning nil, so creating a blank url with stop the download (Alamofire will be removed soon anyway)
+            }
+            let filePath = baseEncryptionModel!.decryptedFilePath()
             if NSFileManager.defaultManager().fileExistsAtPath(filePath) {
                 NSFileManager.defaultManager().removeItemAtPath(filePath, error: nil)
             }

--- a/Digipost/APIClient.swift
+++ b/Digipost/APIClient.swift
@@ -456,7 +456,7 @@ class APIClient : NSObject, NSURLSessionTaskDelegate, NSURLSessionDelegate, NSUR
             letterViewController.attachment = nil
             letterViewController.receipt = nil
         }
-        APIClient.sharedClient.logout()
+        APIClient.sharedClient.logoutThenDeleteAllStoredData()
         NSNotificationCenter.defaultCenter().postNotificationName(kShowLoginViewControllerNotificationName, object: nil)
     }
 

--- a/Digipost/APIClient.swift
+++ b/Digipost/APIClient.swift
@@ -395,7 +395,6 @@ class APIClient : NSObject, NSURLSessionTaskDelegate, NSURLSessionDelegate, NSUR
     func removeTemporaryUploadFiles () {
         let uploadsPath = POSFileManager.sharedFileManager().uploadsFolderPath()
         POSFileManager.sharedFileManager().removeAllFilesInFolder(uploadsPath)
-
     }
 
     private func validate(#oAuthToken: OAuthToken?, validationSuccess: (chosenToken: OAuthToken) -> Void, failure: ((error: NSError) -> Void)?) {
@@ -441,8 +440,6 @@ class APIClient : NSObject, NSURLSessionTaskDelegate, NSURLSessionDelegate, NSUR
             letterViewController.receipt = nil
         }
         APIClient.sharedClient.logout()
-        OAuthToken.removeAllTokens()
-        POSModelManager.sharedManager().deleteAllObjects()
         NSNotificationCenter.defaultCenter().postNotificationName(kShowLoginViewControllerNotificationName, object: nil)
     }
 

--- a/Digipost/APIClient.swift
+++ b/Digipost/APIClient.swift
@@ -191,12 +191,14 @@ class APIClient : NSObject, NSURLSessionTaskDelegate, NSURLSessionDelegate, NSUR
 
     */
     private func logout(#success: () -> Void, failure: (error: APIError) -> ()) {
+        self.session.invalidateAndCancel()
+        Alamofire.Manager.sharedInstance.session.invalidateAndCancel()
         let rootResource = POSRootResource.existingRootResourceInManagedObjectContext(POSModelManager.sharedManager().managedObjectContext)
-        let logoutURI = rootResource.logoutUri
         if rootResource == nil {
             success()
             return
         }
+        let logoutURI = rootResource.logoutUri
         // if validation fails, just delete everything to make sure user will get correctly logged out in app
         validateFullScope(success: {
             let task = self.urlSessionTask(httpMethod.post, url: logoutURI, success: success, failure: failure)

--- a/Digipost/APIClient.swift
+++ b/Digipost/APIClient.swift
@@ -246,7 +246,7 @@ class APIClient : NSObject, NSURLSessionTaskDelegate, NSURLSessionDelegate, NSUR
         self.session.getTasksWithCompletionHandler { (dataTasks, uploadTasks, downloadTasks) -> Void in
             self.cancelTasks(dataTasks)
             self.cancelTasks(uploadTasks)
-            self.cancelTasks(dataTasks)
+            self.cancelTasks(downloadTasks)
             then()
         }
     }

--- a/Digipost/APIClient.swift
+++ b/Digipost/APIClient.swift
@@ -219,7 +219,7 @@ class APIClient : NSObject, NSURLSessionTaskDelegate, NSURLSessionDelegate, NSUR
             if let idPorten4Token = OAuthToken.oAuthTokenWithScope(kOauth2ScopeFull_Idporten4) {
                 self.validate(token: idPorten4Token, then: {
                     let task = self.urlSessionTask(httpMethod.post, url: logoutURI, success: success, failure: failure)
-                task.resume()
+                    task.resume()
                 })
             }
 

--- a/Digipost/APIClient.swift
+++ b/Digipost/APIClient.swift
@@ -223,10 +223,12 @@ class APIClient : NSObject, NSURLSessionTaskDelegate, NSURLSessionDelegate, NSUR
 
             OAuthToken.removeAllTokens()
             POSModelManager.sharedManager().deleteAllObjects()
+            POSFileManager.sharedFileManager().removeAllFiles()
 
         }) { (error) -> Void in
             OAuthToken.removeAllTokens()
             POSModelManager.sharedManager().deleteAllObjects()
+            POSFileManager.sharedFileManager().removeAllFiles()
         }
 
 

--- a/Digipost/APIClient.swift
+++ b/Digipost/APIClient.swift
@@ -181,10 +181,15 @@ class APIClient : NSObject, NSURLSessionTaskDelegate, NSURLSessionDelegate, NSUR
         logout(success: { () -> Void in
             // get run for every time a sucessful scope logs out
             }) { (error) -> () in
-                // just in case, delete token
+                // gets run for every failed request
         }
     }
 
+    /**
+    success and failure blocks are run multiple times depending on how many requests are done
+    logs out OAuth tokens for all scopes in storage
+
+    */
     private func logout(#success: () -> Void, failure: (error: APIError) -> ()) {
         let rootResource = POSRootResource.existingRootResourceInManagedObjectContext(POSModelManager.sharedManager().managedObjectContext)
         let logoutURI = rootResource.logoutUri
@@ -393,10 +398,10 @@ class APIClient : NSObject, NSURLSessionTaskDelegate, NSURLSessionDelegate, NSUR
 
     }
 
-    private func validate(#oAuthToken: OAuthToken?, validationSuccess: (chosenToken: OAuthToken) -> Void, failure: ((error: NSError) -> Void)?) -> APIClient? {
+    private func validate(#oAuthToken: OAuthToken?, validationSuccess: (chosenToken: OAuthToken) -> Void, failure: ((error: NSError) -> Void)?) {
         if oAuthToken?.hasExpired() == false {
             validationSuccess(chosenToken: oAuthToken!)
-            return nil
+            return 
         }
 
         if (oAuthToken?.refreshToken != nil && oAuthToken?.refreshToken != "") {
@@ -427,7 +432,6 @@ class APIClient : NSObject, NSURLSessionTaskDelegate, NSURLSessionDelegate, NSUR
                 assert(false, "NO oauthtoken present in app. Log out!")
             }
         }
-        return nil
     }
 
     private func deleteRefreshTokensAndLogoutUser() {

--- a/Digipost/AccountViewController.swift
+++ b/Digipost/AccountViewController.swift
@@ -200,7 +200,7 @@ class AccountViewController: UIViewController, UIActionSheetDelegate, UIPopoverP
             letterViewController.attachment = nil
             letterViewController.receipt = nil
         }
-        APIClient.sharedClient.logout()
+        APIClient.sharedClient.logoutThenDeleteAllStoredData()
         tableView.reloadData()
         NSNotificationCenter.defaultCenter().postNotificationName(kShowLoginViewControllerNotificationName, object: nil)
     }

--- a/Digipost/AccountViewController.swift
+++ b/Digipost/AccountViewController.swift
@@ -200,10 +200,8 @@ class AccountViewController: UIViewController, UIActionSheetDelegate, UIPopoverP
             letterViewController.attachment = nil
             letterViewController.receipt = nil
         }
-        tableView.reloadData()
         APIClient.sharedClient.logout()
-        OAuthToken.removeAllTokens()
-        POSModelManager.sharedManager().deleteAllObjects()
+        tableView.reloadData()
         NSNotificationCenter.defaultCenter().postNotificationName(kShowLoginViewControllerNotificationName, object: nil)
     }
 


### PR DESCRIPTION
Flow is like this:
Log out 
Try to validate current refresh token
if this validates, cancel all current requests, then run through and make up to four requests canceling each scope from full to idporten4
if validation of refresh token fails, it will just remove everything from database, and don't do any more url requests.

Notice that each of the log out requests calls their complete or failure block, as this is not optimal, since its not shown in the method signature, i haven't refactored it, because this will most likely cause merging problems with the other branches. If it should be refactored, i can add optional complete and failure blocks, since they will ignore if they fail or not. As user does not care if these calls fail or not, it does not matter if we don't do a refactor on this.
