### PR TITLE
Forbedret auto utlogging

### DIFF
--- a/Digipost.xcodeproj/project.pbxproj
+++ b/Digipost.xcodeproj/project.pbxproj
@@ -87,6 +87,8 @@
 		9C8B656C1DE6437100634166 /* APIClient+Banks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C8B656B1DE6437100634166 /* APIClient+Banks.swift */; };
 		9C8B656E1DE6437100634166 /* APIClient+Banks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C8B656B1DE6437100634166 /* APIClient+Banks.swift */; };
 		9CDA58A31E536D5D00FB312B /* Pods_Digipost.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 9C3C11021DF835C40028DF3B /* Pods_Digipost.framework */; };
+		9CF0DC5F1E65CAAA00BBF529 /* AppVersionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CF0DC5E1E65CAAA00BBF529 /* AppVersionManager.swift */; };
+		9CF0DC611E65CAAA00BBF529 /* AppVersionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CF0DC5E1E65CAAA00BBF529 /* AppVersionManager.swift */; };
 		9CFE61611DEC58DD0097A53B /* InvoiceBankAgreement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CFE61601DEC58DD0097A53B /* InvoiceBankAgreement.swift */; };
 		9CFE61631DEC58DD0097A53B /* InvoiceBankAgreement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CFE61601DEC58DD0097A53B /* InvoiceBankAgreement.swift */; };
 		AF00BB5E1A664BD900261E0B /* AccountTableViewDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF00BB5D1A664BD900261E0B /* AccountTableViewDataSource.swift */; };
@@ -671,6 +673,7 @@
 		9C9216461E53408200EF9858 /* Pods_Digipost.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Pods_Digipost.framework; path = "Pods/../build/Debug-iphoneos/Pods_Digipost.framework"; sourceTree = "<group>"; };
 		9C9216481E53451600EF9858 /* Pods_Digipost.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Pods_Digipost.framework; path = "Pods/../build/Debug-iphoneos/Pods_Digipost.framework"; sourceTree = "<group>"; };
 		9CCC5A0A1E5B0205001F0FCC /* LUKeychainAccess.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = LUKeychainAccess.framework; path = "../../../Library/Developer/Xcode/DerivedData/Digipost-emgyuvwaqglndhamwjquhpwcfkoo/Build/Products/Debug-iphonesimulator/LUKeychainAccess/LUKeychainAccess.framework"; sourceTree = "<group>"; };
+		9CF0DC5E1E65CAAA00BBF529 /* AppVersionManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppVersionManager.swift; sourceTree = "<group>"; };
 		9CFE61601DEC58DD0097A53B /* InvoiceBankAgreement.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InvoiceBankAgreement.swift; sourceTree = "<group>"; };
 		AF00BB5D1A664BD900261E0B /* AccountTableViewDataSource.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AccountTableViewDataSource.swift; sourceTree = "<group>"; };
 		AF199D521AA72EE6001F252A /* OnboardingLoginViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = OnboardingLoginViewController.swift; sourceTree = "<group>"; };
@@ -1372,6 +1375,7 @@
 				EC46E65C19F641010085CA82 /* NSManagedObject+Attributes.swift */,
 				F885F89E1CC8FE0100ACE62D /* APIClient+GCM.swift */,
 				9C8B656B1DE6437100634166 /* APIClient+Banks.swift */,
+				9CF0DC5E1E65CAAA00BBF529 /* AppVersionManager.swift */,
 			);
 			name = Client;
 			sourceTree = "<group>";
@@ -2040,6 +2044,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9CF0DC5F1E65CAAA00BBF529 /* AppVersionManager.swift in Sources */,
 				ECB2BEA01B452EC5008E32E8 /* ComposerViewController+UIPresentationController.swift in Sources */,
 				ECCC5CAF19C83DFA00FACAA1 /* UploadGuideViewController.swift in Sources */,
 				EC3A4F161B8C7C2D00B8D60E /* Array+TextStyleModel.swift in Sources */,
@@ -2269,6 +2274,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				9CF0DC611E65CAAA00BBF529 /* AppVersionManager.swift in Sources */,
 				F8AE1BEC1CD374B40009B2F9 /* ComposerViewController+UIPresentationController.swift in Sources */,
 				F8AE1BED1CD374B40009B2F9 /* UploadGuideViewController.swift in Sources */,
 				F8AE1BEE1CD374B40009B2F9 /* Array+TextStyleModel.swift in Sources */,

--- a/Digipost/AppVersionManager.swift
+++ b/Digipost/AppVersionManager.swift
@@ -1,0 +1,101 @@
+//
+// Copyright (C) Posten Norge AS
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//         http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+
+import LUKeychainAccess
+
+@objc class AppVersionManager: NSObject{
+    
+    static let APP_VERSIONS_IN_KEYCHAIN = "AppVersionsInKeychain"
+    static let APP_VERSIONS_FROM_IN_DEFAULTS = "AppVersionsInUserDefaults"
+    
+    static func deleteOldTokensIfReinstall() {
+        
+        if reInstall() {
+            clearTokens()
+        }
+        
+        updateAppVersionsInUserDefaults()
+        updateAppVersionsInKeychain()
+    }
+    
+    class func reInstall() -> Bool {        
+        return oldVersionsFoundInKeychain() && !oldVersionsFoundInUserDefaults()
+    }
+    
+    class func clearTokens() {
+        OAuthToken.removeAllTokens()
+        OAuthToken.removeRefreshToken()
+    }
+    
+    class func getAppVersion() -> String? {
+        let dictionary = Bundle.main.infoDictionary!
+        return dictionary["CFBundleVersion"] as? String
+    }
+    
+    //UserDefault - App Versions
+    
+    class func oldVersionsFoundInUserDefaults() -> Bool {
+        return getAppVersionsFromUserDefaults() != nil
+    }
+    
+    class func getAppVersionsFromUserDefaults() -> [String]? {
+        return UserDefaults.standard.object(forKey: APP_VERSIONS_FROM_IN_DEFAULTS) as? [String]
+    }
+    
+    class func updateAppVersionsInUserDefaults() {        
+        if let currentAppVersion = getAppVersion() {
+            
+            var appVersions : [String] = [] 
+            
+            if let existingAppVersions = getAppVersionsFromUserDefaults() {
+                appVersions = existingAppVersions
+            }
+            
+            guard currentAppVersion != appVersions.last else {return}
+            appVersions.append(currentAppVersion)
+            
+            UserDefaults.standard.set(appVersions, forKey: APP_VERSIONS_FROM_IN_DEFAULTS)
+        }
+    }
+    
+    //Keychain - App Versions
+    
+    class func oldVersionsFoundInKeychain() -> Bool {
+        return getAppVersionsFromKeychain() != nil
+    }
+    
+    class func getAppVersionsFromKeychain() -> [String]? {
+        let keychainAccess = LUKeychainAccess()
+        return keychainAccess.object(forKey: APP_VERSIONS_IN_KEYCHAIN) as? [String]
+    }
+    
+    class func updateAppVersionsInKeychain() {        
+        if let currentAppVersion = getAppVersion() {
+            
+            var appVersions : [String] = [] 
+            
+            if let existingAppVersions = getAppVersionsFromKeychain() {
+                appVersions = existingAppVersions
+            }
+            
+            guard currentAppVersion != appVersions.last else {return}
+            appVersions.append(currentAppVersion)
+            
+            let keychainAccess = LUKeychainAccess()
+            keychainAccess.setObject(appVersions, forKey: APP_VERSIONS_IN_KEYCHAIN)
+        }
+    }
+}

--- a/Digipost/AppVersionManager.swift
+++ b/Digipost/AppVersionManager.swift
@@ -40,11 +40,6 @@ import LUKeychainAccess
         OAuthToken.removeRefreshToken()
     }
     
-    class func getAppVersion() -> String? {
-        let dictionary = Bundle.main.infoDictionary!
-        return dictionary["CFBundleVersion"] as? String
-    }
-    
     //UserDefault - App Versions
     
     class func oldVersionsFoundInUserDefaults() -> Bool {
@@ -79,6 +74,11 @@ import LUKeychainAccess
     }
     
     //Common
+    
+    class func getAppVersion() -> String? {
+        let dictionary = Bundle.main.infoDictionary!
+        return dictionary["CFBundleVersion"] as? String
+    }
     
     class func appendCurrentAppVersion( oldAppVersions: [String]?) -> [String] {
         

--- a/Digipost/AppVersionManager.swift
+++ b/Digipost/AppVersionManager.swift
@@ -56,19 +56,8 @@ import LUKeychainAccess
     }
     
     class func updateAppVersionsInUserDefaults() {        
-        if let currentAppVersion = getAppVersion() {
-            
-            var appVersions : [String] = [] 
-            
-            if let existingAppVersions = getAppVersionsFromUserDefaults() {
-                appVersions = existingAppVersions
-            }
-            
-            guard currentAppVersion != appVersions.last else {return}
-            appVersions.append(currentAppVersion)
-            
-            UserDefaults.standard.set(appVersions, forKey: APP_VERSIONS_FROM_IN_DEFAULTS)
-        }
+        let appVersions = appendCurrentAppVersion(oldAppVersions: getAppVersionsFromUserDefaults())
+        UserDefaults.standard.set(appVersions, forKey: APP_VERSIONS_FROM_IN_DEFAULTS)
     }
     
     //Keychain - App Versions
@@ -83,19 +72,28 @@ import LUKeychainAccess
     }
     
     class func updateAppVersionsInKeychain() {        
-        if let currentAppVersion = getAppVersion() {
-            
-            var appVersions : [String] = [] 
-            
-            if let existingAppVersions = getAppVersionsFromKeychain() {
-                appVersions = existingAppVersions
-            }
-            
-            guard currentAppVersion != appVersions.last else {return}
-            appVersions.append(currentAppVersion)
-            
-            let keychainAccess = LUKeychainAccess()
-            keychainAccess.setObject(appVersions, forKey: APP_VERSIONS_IN_KEYCHAIN)
+        let appVersions = appendCurrentAppVersion(oldAppVersions: getAppVersionsFromKeychain())
+        
+        let keychainAccess = LUKeychainAccess()
+        keychainAccess.setObject(appVersions, forKey: APP_VERSIONS_IN_KEYCHAIN)
+    }
+    
+    //Common
+    
+    class func appendCurrentAppVersion( oldAppVersions: [String]?) -> [String] {
+        
+        var appVersions : [String] = []
+        
+        if let existing = oldAppVersions {
+            appVersions = existing
         }
+        
+        if let currentAppVersion = getAppVersion() {
+            guard currentAppVersion != appVersions.last else {return appVersions}
+            
+            appVersions.append(currentAppVersion)
+        }
+        
+        return appVersions
     }
 }

--- a/Digipost/AppVersionManager.swift
+++ b/Digipost/AppVersionManager.swift
@@ -51,7 +51,7 @@ import LUKeychainAccess
     }
     
     class func updateAppVersionsInUserDefaults() {        
-        let appVersions = appendCurrentAppVersion(oldAppVersions: getAppVersionsFromUserDefaults())
+        let appVersions = getCurrentAppVersions(oldAppVersions: getAppVersionsFromUserDefaults())
         UserDefaults.standard.set(appVersions, forKey: APP_VERSIONS_FROM_IN_DEFAULTS)
     }
     
@@ -67,7 +67,7 @@ import LUKeychainAccess
     }
     
     class func updateAppVersionsInKeychain() {        
-        let appVersions = appendCurrentAppVersion(oldAppVersions: getAppVersionsFromKeychain())
+        let appVersions = getCurrentAppVersions(oldAppVersions: getAppVersionsFromKeychain())
         
         let keychainAccess = LUKeychainAccess()
         keychainAccess.setObject(appVersions, forKey: APP_VERSIONS_IN_KEYCHAIN)
@@ -80,7 +80,7 @@ import LUKeychainAccess
         return dictionary["CFBundleVersion"] as? String
     }
     
-    class func appendCurrentAppVersion( oldAppVersions: [String]?) -> [String] {
+    class func getCurrentAppVersions( oldAppVersions: [String]?) -> [String] {
         
         var appVersions : [String] = []
         

--- a/Digipost/AppVersionManager.swift
+++ b/Digipost/AppVersionManager.swift
@@ -68,7 +68,6 @@ import LUKeychainAccess
     
     class func updateAppVersionsInKeychain() {        
         let appVersions = getCurrentAppVersions(oldAppVersions: getAppVersionsFromKeychain())
-        
         let keychainAccess = LUKeychainAccess()
         keychainAccess.setObject(appVersions, forKey: APP_VERSIONS_IN_KEYCHAIN)
     }

--- a/Digipost/SHCAppDelegate.m
+++ b/Digipost/SHCAppDelegate.m
@@ -54,7 +54,7 @@
 {
     [[UIBarButtonItem appearance] setBackButtonTitlePositionAdjustment:UIOffsetMake(-500, -500) forBarMetrics:UIBarMetricsDefault];
     
-    [AppVersionManager deleteOldTokensIfNeeded];
+    [AppVersionManager deleteOldTokensIfReinstall];
     [self setupGoogleAnalytics];
         
     [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleLightContent];

--- a/Digipost/SHCAppDelegate.m
+++ b/Digipost/SHCAppDelegate.m
@@ -54,7 +54,7 @@
 {
     [[UIBarButtonItem appearance] setBackButtonTitlePositionAdjustment:UIOffsetMake(-500, -500) forBarMetrics:UIBarMetricsDefault];
     
-    [self deletePossibleOldTokensIfFirstRun];
+    [AppVersionManager deleteOldTokensIfNeeded];
     [self setupGoogleAnalytics];
         
     [[UIApplication sharedApplication] setStatusBarStyle:UIStatusBarStyleLightContent];
@@ -314,16 +314,6 @@
 
 - (void)applicationWillTerminate:(UIApplication *)application {
     [[POSFileManager sharedFileManager] removeAllDecryptedFiles];
-}
-
-- (void) deletePossibleOldTokensIfFirstRun {
-
-    if (![[NSUserDefaults standardUserDefaults] objectForKey:@"FirstRun"]) {
-        [OAuthToken removeAllTokens];
-        [OAuthToken removeRefreshToken];
-        [[NSUserDefaults standardUserDefaults] setValue:@"1strun" forKey:@"FirstRun"];
-        [[NSUserDefaults standardUserDefaults] synchronize];
-    }
 }
 
 - (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation {

--- a/Digipost/SHCOAuthViewController.m
+++ b/Digipost/SHCOAuthViewController.m
@@ -34,7 +34,7 @@ NSString *const kOAuthViewControllerScreenName = @"OAuth";
 
 NSString *const kGoogleAnalyticsErrorEventCategory = @"Error";
 NSString *const kGoogleAnalyticsErrorEventAction = @"OAuth";
-Boolean *tryToFillUsing1Password = false;
+Boolean tryToFillUsing1Password = false;
 
 @interface SHCOAuthViewController () <UIWebViewDelegate, NSURLConnectionDelegate>
 


### PR DESCRIPTION
Holder styr på installerte og gamle app-versjoner for å kunne logge ut brukere automatisk ved behov.

For å dekke behov for automatisk utlogging dersom bruker har hatt app tidligere installert lagres app-versjoner til KeyChain (persistent, som overlever sletting av app) og til UserDefaults som fjernes ved sletting. Dermed kan appen detektere reinstallasjon og slette tokens dersom dette skjer.