### PR TITLE
Eksterne lenker via brev på i pad

### DIFF
--- a/Digipost/AppVersionManager.swift
+++ b/Digipost/AppVersionManager.swift
@@ -19,7 +19,7 @@ import LUKeychainAccess
 @objc class AppVersionManager: NSObject{
     
     static let APP_VERSIONS_IN_KEYCHAIN = "AppVersionsInKeychain"
-    static let APP_VERSIONS_FROM_IN_DEFAULTS = "AppVersionsInUserDefaults"
+    static let APP_VERSIONS_IN_USER_DEFAULTS = "AppVersionsInUserDefaults"
     
     static func deleteOldTokensIfReinstall() {
         
@@ -47,12 +47,12 @@ import LUKeychainAccess
     }
     
     class func getAppVersionsFromUserDefaults() -> [String]? {
-        return UserDefaults.standard.object(forKey: APP_VERSIONS_FROM_IN_DEFAULTS) as? [String]
+        return UserDefaults.standard.object(forKey: APP_VERSIONS_IN_USER_DEFAULTS) as? [String]
     }
     
     class func updateAppVersionsInUserDefaults() {        
         let appVersions = getCurrentAppVersions(oldAppVersions: getAppVersionsFromUserDefaults())
-        UserDefaults.standard.set(appVersions, forKey: APP_VERSIONS_FROM_IN_DEFAULTS)
+        UserDefaults.standard.set(appVersions, forKey: APP_VERSIONS_IN_USER_DEFAULTS)
     }
     
     //Keychain - App Versions

--- a/Digipost/Base.lproj/Main_iPad.storyboard
+++ b/Digipost/Base.lproj/Main_iPad.storyboard
@@ -16,7 +16,7 @@
             <objects>
                 <navigationController storyboardIdentifier="LoginNavigationController" definesPresentationContext="YES" id="yzu-Np-c5M" sceneMemberID="viewController">
                     <simulatedNavigationBarMetrics key="simulatedTopBarMetrics" translucent="NO" prompted="NO"/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" translucent="NO" id="Scb-lQ-TPi">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" translucent="NO" id="Scb-lQ-TPi">
                         <rect key="frame" x="0.0" y="0.0" width="1000" height="1000"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -1400,7 +1400,7 @@
             <objects>
                 <navigationController id="OdY-44-cdI" sceneMemberID="viewController">
                     <navigationItem key="navigationItem" id="Upo-UA-iRO"/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" translucent="NO" id="s3L-N0-7eL">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" translucent="NO" id="s3L-N0-7eL">
                         <rect key="frame" x="0.0" y="0.0" width="320" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>
@@ -1697,7 +1697,7 @@
             <objects>
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="dlF-6U-ivY" sceneMemberID="viewController">
                     <toolbarItems/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" misplaced="YES" id="Dz8-9m-wOS">
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="Dz8-9m-wOS">
                         <rect key="frame" x="0.0" y="0.0" width="768" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </navigationBar>

--- a/Digipost/POSLetterViewController.m
+++ b/Digipost/POSLetterViewController.m
@@ -379,7 +379,8 @@ NSString *const kLetterViewControllerScreenName = @"Letter";
                                  }];
         [alert addAction:open];
         [alert addAction:cancel];
-
+        UIPopoverPresentationController *popPresenter = [alert popoverPresentationController];
+        popPresenter.sourceView = self.view;
         [self presentViewController:alert animated:YES completion:nil];
         return NO;
     }


### PR DESCRIPTION
Fikser bug hvor appen kræsjet dersom man forsøkte å åpne eksterne lenker fra et dokument på iPad.

Rettet også skrivefeil i tidligere PR og autogenererte endringer i iPad storyboard