### PR TITLE
Bugfix dropper tastatur for høyere innlogging

### DIFF
--- a/Digipost.xcodeproj/xcshareddata/xcschemes/Digipost.xcscheme
+++ b/Digipost.xcodeproj/xcshareddata/xcschemes/Digipost.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0910"
+   LastUpgradeVersion = "0920"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Digipost.xcodeproj/xcshareddata/xcschemes/DigipostQA.xcscheme
+++ b/Digipost.xcodeproj/xcshareddata/xcschemes/DigipostQA.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0910"
+   LastUpgradeVersion = "0920"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Digipost.xcodeproj/xcshareddata/xcschemes/DigipostUnitTests.xcscheme
+++ b/Digipost.xcodeproj/xcshareddata/xcschemes/DigipostUnitTests.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0910"
+   LastUpgradeVersion = "0920"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Digipost/Digipost.plist
+++ b/Digipost/Digipost.plist
@@ -27,11 +27,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.9.9</string>
+	<string>3.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>210</string>
+	<string>211</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/Digipost/DigipostQA.plist
+++ b/Digipost/DigipostQA.plist
@@ -27,11 +27,11 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>2.9.9</string>
+	<string>3.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>210</string>
+	<string>211</string>
 	<key>ITSAppUsesNonExemptEncryption</key>
 	<false/>
 	<key>LSRequiresIPhoneOS</key>

--- a/Digipost/SHCOAuthViewController.m
+++ b/Digipost/SHCOAuthViewController.m
@@ -67,6 +67,7 @@ Boolean tryToFillUsing1Password = false;
 
     [self remove1PasswordButtonIfNotNormalLoginScope];
     if (self.scope == kOauth2ScopeFull) {
+        [self.webView setKeyboardDisplayRequiresUserAction:NO]; // Må ikke brukes for høyere innlogging fordi den skaper en fokus-bug med innlogging i buypass-webview
         if ([UIDevice currentDevice].userInterfaceIdiom != UIUserInterfaceIdiomPad) {
             self.navigationItem.leftBarButtonItem.title = NSLocalizedString(@"GENERIC_CANCEL_BUTTON_TITLE", @"Cancel");
             [self.navigationItem.leftBarButtonItem setTitleTextAttributes:@{ NSForegroundColorAttributeName : [UIColor colorWithWhite:1.0
@@ -78,8 +79,6 @@ Boolean tryToFillUsing1Password = false;
     }
 
     [self presentAuthenticationWebView];
-
-    [self.webView setKeyboardDisplayRequiresUserAction:NO];
 }
 
 - (void)viewWillDisappear:(BOOL)animated


### PR DESCRIPTION
Fjerner ekstra håndtering av keyboard ved høyere innlogging i ID-porten.
Gjøres fordi det skaper et problem i kombinasjon med riktig fokus Buypass sin webview-innlogging

Testet på device og simulator med Passord, ID-porten Buypass, BankId

Dette medfører at brukere ved innlogging på høyere sikkerhetsnivå ikke får opp tastatur automatisk, men må klikke i input-felt selv.