### PR TITLE
IPadOS-bugfix

### DIFF
--- a/Digipost.xcodeproj/project.pbxproj
+++ b/Digipost.xcodeproj/project.pbxproj
@@ -2280,7 +2280,7 @@
 				CODE_SIGN_ENTITLEMENTS = Digipost/Digipost.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 255;
+				CURRENT_PROJECT_VERSION = 260;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = KMS8B8MK42;
 				ENABLE_BITCODE = NO;
@@ -2310,7 +2310,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)",
 				);
-				MARKETING_VERSION = 3.4.0;
+				MARKETING_VERSION = 3.5.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) -DDEBUG";
 				PRODUCT_BUNDLE_IDENTIFIER = no.posten.Digipost;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2339,7 +2339,7 @@
 				CODE_SIGN_ENTITLEMENTS = Digipost/Digipost.entitlements;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
-				CURRENT_PROJECT_VERSION = 255;
+				CURRENT_PROJECT_VERSION = 260;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = KMS8B8MK42;
 				ENABLE_BITCODE = NO;
@@ -2369,7 +2369,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)",
 				);
-				MARKETING_VERSION = 3.4.0;
+				MARKETING_VERSION = 3.5.0;
 				OTHER_SWIFT_FLAGS = "$(inherited)";
 				PRODUCT_BUNDLE_IDENTIFIER = no.posten.Digipost;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Digipost/Base.lproj/Main_iPad.storyboard
+++ b/Digipost/Base.lproj/Main_iPad.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15505" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="H1p-Uh-vWS">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="15705" targetRuntime="iOS.CocoaTouch.iPad" propertyAccessControl="none" useAutolayout="YES" colorMatched="YES" initialViewController="H1p-Uh-vWS">
     <device id="ipad9_7" orientation="portrait" layout="fullscreen" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15510"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="15706"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -352,7 +352,7 @@
                         <outlet property="shadowView" destination="xHm-UB-Jqi" id="lSw-3z-9AE"/>
                         <outlet property="stackView" destination="wL3-bf-usk" id="a3X-TD-eZp"/>
                         <outlet property="webView" destination="yW3-Fy-eNQ" id="S0L-0e-pT3"/>
-                        <segue destination="OdY-44-cdI" kind="push" identifier="askForhigherAuthenticationLevelSegue" id="Yw9-YX-822"/>
+                        <segue destination="OdY-44-cdI" kind="modal" identifier="askForhigherAuthenticationLevelSegue" modalPresentationStyle="fullScreen" id="Yw9-YX-822"/>
                         <segue destination="8G3-Ke-Q07" kind="push" identifier="invoiceOptionsSegue" id="rUH-Vz-GEc"/>
                         <segue destination="Rql-hZ-HXF" kind="push" identifier="showExternalLinkWebview" id="Toe-Fs-Rv2"/>
                     </connections>
@@ -524,7 +524,7 @@
                                             <nil key="highlightedColor"/>
                                         </label>
                                         <imageView hidden="YES" userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="invoice-list-icon-unpaid" translatesAutoresizingMaskIntoConstraints="NO" id="ZIe-sk-VbV">
-                                            <rect key="frame" x="7" y="67" width="28" height="30"/>
+                                            <rect key="frame" x="7" y="67" width="14" height="15"/>
                                         </imageView>
                                         <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="SENDER" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="fJI-uk-1YP" userLabel="Sender Label">
                                             <rect key="frame" x="25" y="47" width="209" height="15.5"/>
@@ -676,10 +676,10 @@
                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                     <subviews>
                         <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="l2F-in-Zag" userLabel="No Documents View">
-                            <rect key="frame" x="0.0" y="36.5" width="320" height="387.5"/>
+                            <rect key="frame" x="0.0" y="116.5" width="320" height="227.5"/>
                             <subviews>
                                 <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="NO_DOCUMENTS" textAlignment="center" lineBreakMode="wordWrap" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" preferredMaxLayoutWidth="260" translatesAutoresizingMaskIntoConstraints="NO" id="EJR-4a-CZ8" userLabel="No Documents Label">
-                                    <rect key="frame" x="30" y="347" width="260" height="20.5"/>
+                                    <rect key="frame" x="30" y="187" width="260" height="20.5"/>
                                     <constraints>
                                         <constraint firstAttribute="height" relation="greaterThanOrEqual" priority="249" constant="21" id="fNk-yO-pLp"/>
                                     </constraints>
@@ -688,7 +688,7 @@
                                     <nil key="highlightedColor"/>
                                 </label>
                                 <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="tom_mappe_breven" translatesAutoresizingMaskIntoConstraints="NO" id="sf8-FE-eTx" userLabel="No Documents Image View">
-                                    <rect key="frame" x="28.5" y="8" width="264" height="320"/>
+                                    <rect key="frame" x="94.5" y="8" width="132" height="160"/>
                                     <constraints>
                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="101" id="GtI-Pm-p8H"/>
                                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="117" id="c9U-I3-rvf"/>
@@ -1025,7 +1025,7 @@
                                 <nil key="highlightedColor"/>
                             </label>
                             <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="Lastopp_norsk_vertikal" translatesAutoresizingMaskIntoConstraints="NO" id="uVW-gJ-9oa">
-                                <rect key="frame" x="-160" y="40" width="640" height="654"/>
+                                <rect key="frame" x="0.0" y="40" width="320" height="327"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="uVW-gJ-9oa" secondAttribute="height" multiplier="320:327" id="b3J-Vu-cgc"/>
                                 </constraints>

--- a/Digipost/UploadMenuDataSource.swift
+++ b/Digipost/UploadMenuDataSource.swift
@@ -23,7 +23,7 @@ class UploadMenuDataSource: NSObject, UITableViewDataSource {
     }
     
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return 3
+        return 2
     }
     
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -44,10 +44,7 @@ class UploadMenuDataSource: NSObject, UITableViewDataSource {
         case 1:
             cell.titleLabel.text = NSLocalizedString("upload action sheet camera roll button", comment:"button that uploads from camera roll")
             cell.iconImage.image = UIImage(named: "Upload_small")
-        case 2:
-            cell.titleLabel.text = NSLocalizedString( "upload action sheet other file", comment:"From other app")
-            cell.iconImage.image = UIImage.templateImage("Upload_apps")
-            cell.iconImage.tintColor = UIColor.white
+
         default:
             assert(false)
         }

--- a/Digipost/UploadMenuViewController.swift
+++ b/Digipost/UploadMenuViewController.swift
@@ -41,8 +41,6 @@ class UploadMenuViewController: UIViewController, UITableViewDelegate {
             uploadImageController.showCameraCaptureInViewController(self)
         case 1:
             uploadImageController.showPhotoLibraryPickerInViewController(self)
-        case 2:
-            performSegue(withIdentifier: "uploadGuideSegue", sender: self)
         default:
             assert(false)
         }


### PR DESCRIPTION
ref Support https://trello.com/c/M5d9QsOE/406-sf-15531710-last-opp-på-ios
- Fikset bug med oppautentisering etter Apple endret defaultoppførsel på push/modal visning.
- Fjernet opplastnings-veiledning til en metode som ikke har fungert på en stund. kun bildeopplastning og kamera er støttet i dag. 

Testet på Simulator og device.  
Sendt til Apple-godkjenning